### PR TITLE
bump golangci-linter version and address newborn issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,8 @@ issues:
         - funlen
         - maligned
         - golint
+        - paralleltest
+        - testpackage
     - path: github/client
       linters:
         - gosec
@@ -32,6 +34,9 @@ linters:
     # should be enabled shortly
     - funlen
     - dupl
+    - nlreturn
+    - exhaustivestruct
+    - cyclop
 
 linters-settings:
   govet:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ deps:
 	@ echo "-> Installing project dependencies..."
 	@ GO111MODULE=off go get -u github.com/myitcv/gobin
 	@ $(GOBIN)/gobin golang.org/x/lint/golint
-	@ curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.22.0
+	@ curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.37.0
 	@ echo "-> Done."
 
 ## Formats code and fixes as many as possible linter errors
@@ -60,4 +60,3 @@ test:
 	@ echo "-> Running unit tests..."
 	@ go test -timeout 10s -p 4 -race -count=1 ./...
 	@ echo "-> Done."
-

--- a/assert/any.go
+++ b/assert/any.go
@@ -7,14 +7,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/values"
 )
 
-// AssertableAny is the assertable structure for interface{} values
+// AssertableAny is the assertable structure for interface{} values.
 type AssertableAny struct {
 	t      *testing.T
 	actual values.AnyValue
 }
 
-// That returns an AssertableAny structure initialized with the test reference and the actual value to assert
+// That returns an AssertableAny structure initialized with the test reference and the actual value to assert.
 func That(t *testing.T, actual interface{}) AssertableAny {
+	t.Helper()
 	return AssertableAny{
 		t:      t,
 		actual: values.NewAnyValue(actual),
@@ -22,7 +23,7 @@ func That(t *testing.T, actual interface{}) AssertableAny {
 }
 
 // IsEqualTo asserts if the expected interface is equal to the assertable value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableAny) IsEqualTo(expected interface{}) AssertableAny {
 	if !a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -31,7 +32,7 @@ func (a AssertableAny) IsEqualTo(expected interface{}) AssertableAny {
 }
 
 // IsNotEqualTo asserts if the expected interface is not qual to the assertable value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableAny) IsNotEqualTo(expected interface{}) AssertableAny {
 	if a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -39,7 +40,7 @@ func (a AssertableAny) IsNotEqualTo(expected interface{}) AssertableAny {
 	return a
 }
 
-// IsNil asserts if the expected value is nil
+// IsNil asserts if the expected value is nil.
 func (a AssertableAny) IsNil() AssertableAny {
 	if !a.actual.IsNil() {
 		a.t.Error(shouldBeNil(a.actual))
@@ -47,7 +48,7 @@ func (a AssertableAny) IsNil() AssertableAny {
 	return a
 }
 
-// IsNotNil asserts if the expected value is not nil
+// IsNotNil asserts if the expected value is not nil.
 func (a AssertableAny) IsNotNil() AssertableAny {
 	if !a.actual.IsNotNil() {
 		a.t.Error(shouldNotBeNil(a.actual))
@@ -55,19 +56,19 @@ func (a AssertableAny) IsNotNil() AssertableAny {
 	return a
 }
 
-// IsTrue asserts if the expected value is true
+// IsTrue asserts if the expected value is true.
 func (a AssertableAny) IsTrue() AssertableAny {
 	a.IsEqualTo(true)
 	return a
 }
 
-// IsFalse asserts if the expected value is false
+// IsFalse asserts if the expected value is false.
 func (a AssertableAny) IsFalse() AssertableAny {
 	a.IsEqualTo(false)
 	return a
 }
 
-// HasTypeOf asserts if the expected value has the type of a given value
+// HasTypeOf asserts if the expected value has the type of a given value.
 func (a AssertableAny) HasTypeOf(t reflect.Type) AssertableAny {
 	if !a.actual.HasTypeOf(t) {
 		a.t.Error(shouldHaveType(a.actual, t))

--- a/assert/any_test.go
+++ b/assert/any_test.go
@@ -109,6 +109,41 @@ func TestAssertable_IsFalse(t *testing.T) {
 	}
 }
 
+func TestAssertableAny_IsEqualTo(t *testing.T) {
+	tests := []struct {
+		name       string
+		actual     interface{}
+		expected   interface{}
+		shouldFail bool
+	}{
+		{
+			name:       "should assert a string slice which is not equal to expected",
+			actual:     []string{"123", "321"},
+			expected:   []string{"123"},
+			shouldFail: true,
+		},
+		{
+			name:       "should assert a string slice which is equal to expected",
+			actual:     []string{"123", "321"},
+			expected:   []string{"123", "321"},
+			shouldFail: false,
+		},
+		{
+			name:       "should assert a string slice when the expected is of different type",
+			actual:     []string{"123"},
+			expected:   "123",
+			shouldFail: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			test := &testing.T{}
+			That(test, tt.actual).IsEqualTo(tt.expected)
+			ThatBool(t, test.Failed()).IsEqualTo(tt.shouldFail)
+		})
+	}
+}
+
 func TestAssertableAny_HasTypeOf(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/assert/bool.go
+++ b/assert/bool.go
@@ -6,14 +6,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/values"
 )
 
-// AssertableBool is the assertable structure for bool values
+// AssertableBool is the assertable structure for bool values.
 type AssertableBool struct {
 	t      *testing.T
 	actual values.BoolValue
 }
 
-// ThatBool returns an AssertableBool structure initialized with the test reference and the actual bool value to assert
+// ThatBool returns an AssertableBool structure initialized with the test reference and the actual bool value to assert.
 func ThatBool(t *testing.T, actual bool) AssertableBool {
+	t.Helper()
 	return AssertableBool{
 		t:      t,
 		actual: values.NewBoolValue(actual),
@@ -21,7 +22,7 @@ func ThatBool(t *testing.T, actual bool) AssertableBool {
 }
 
 // IsEqualTo asserts if the expected bool is equal to the assertable bool value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableBool) IsEqualTo(expected interface{}) AssertableBool {
 	if !a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -30,7 +31,7 @@ func (a AssertableBool) IsEqualTo(expected interface{}) AssertableBool {
 }
 
 // IsNotEqualTo asserts if the expected bool is not equal to the assertable bool value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableBool) IsNotEqualTo(expected interface{}) AssertableBool {
 	if a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -38,12 +39,12 @@ func (a AssertableBool) IsNotEqualTo(expected interface{}) AssertableBool {
 	return a
 }
 
-// IsTrue asserts if the expected bool value is true
+// IsTrue asserts if the expected bool value is true.
 func (a AssertableBool) IsTrue() AssertableBool {
 	return a.IsEqualTo(true)
 }
 
-// IsFalse asserts if the expected bool value is false
+// IsFalse asserts if the expected bool value is false.
 func (a AssertableBool) IsFalse() AssertableBool {
 	return a.IsEqualTo(false)
 }

--- a/assert/duration.go
+++ b/assert/duration.go
@@ -7,14 +7,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/values"
 )
 
-// AssertableDuration is the assertable structure for time.Duration values
+// AssertableDuration is the assertable structure for time.Duration values.
 type AssertableDuration struct {
 	t      *testing.T
 	actual values.DurationValue
 }
 
-// ThatDuration returns an AssertableDuration structure initialized with the test reference and the actual value to assert
+// ThatDuration returns an AssertableDuration structure initialized with the test reference and the actual value to assert.
 func ThatDuration(t *testing.T, actual time.Duration) AssertableDuration {
+	t.Helper()
 	return AssertableDuration{
 		t:      t,
 		actual: values.NewDurationValue(actual),
@@ -22,7 +23,7 @@ func ThatDuration(t *testing.T, actual time.Duration) AssertableDuration {
 }
 
 // IsEqualTo asserts if the expected time.Duration is equal to the assertable time.Duration value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableDuration) IsEqualTo(expected time.Duration) AssertableDuration {
 	if a.actual.IsNotEqualTo(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -31,7 +32,7 @@ func (a AssertableDuration) IsEqualTo(expected time.Duration) AssertableDuration
 }
 
 // IsNotEqualTo asserts if the expected time.Duration is not equal to the assertable time.Duration value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableDuration) IsNotEqualTo(expected time.Duration) AssertableDuration {
 	if a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -40,7 +41,7 @@ func (a AssertableDuration) IsNotEqualTo(expected time.Duration) AssertableDurat
 }
 
 // IsShorterThan asserts if the assertable time.Duration value is shorter than the expected value
-// It errors the tests if is not shorter
+// It errors the tests if is not shorter.
 func (a AssertableDuration) IsShorterThan(expected time.Duration) AssertableDuration {
 	if !a.actual.IsShorterThan(expected) {
 		a.t.Error(shouldBeShorter(a.actual, expected))
@@ -49,7 +50,7 @@ func (a AssertableDuration) IsShorterThan(expected time.Duration) AssertableDura
 }
 
 // IsLongerThan asserts if the assertable time.v value is longer than the expected value
-// It errors the tests if is not longer
+// It errors the tests if is not longer.
 func (a AssertableDuration) IsLongerThan(expected time.Duration) AssertableDuration {
 	if !a.actual.IsLongerThan(expected) {
 		a.t.Error(shouldBeLonger(a.actual, expected))

--- a/assert/int.go
+++ b/assert/int.go
@@ -6,14 +6,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/values"
 )
 
-// AssertableInt is the assertable structure for int values
+// AssertableInt is the assertable structure for int values.
 type AssertableInt struct {
 	t      *testing.T
 	actual values.IntValue
 }
 
-// ThatInt returns an AssertableInt structure initialized with the test reference and the actual value to assert
+// ThatInt returns an AssertableInt structure initialized with the test reference and the actual value to assert.
 func ThatInt(t *testing.T, actual int) AssertableInt {
+	t.Helper()
 	return AssertableInt{
 		t:      t,
 		actual: values.NewIntValue(actual),
@@ -21,7 +22,7 @@ func ThatInt(t *testing.T, actual int) AssertableInt {
 }
 
 // IsEqualTo asserts if the expected int is equal to the assertable int value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableInt) IsEqualTo(expected int) AssertableInt {
 	if !a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -30,7 +31,7 @@ func (a AssertableInt) IsEqualTo(expected int) AssertableInt {
 }
 
 // IsNotEqualTo asserts if the expected int is not equal to the assertable int value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableInt) IsNotEqualTo(expected int) AssertableInt {
 	if a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -39,7 +40,7 @@ func (a AssertableInt) IsNotEqualTo(expected int) AssertableInt {
 }
 
 // IsGreaterThan asserts if the assertable int value is greater than the expected value
-// It errors the tests if is not greater
+// It errors the tests if is not greater.
 func (a AssertableInt) IsGreaterThan(expected int) AssertableInt {
 	if !a.actual.IsGreaterThan(expected) {
 		a.t.Error(shouldBeGreater(a.actual, expected))
@@ -48,7 +49,7 @@ func (a AssertableInt) IsGreaterThan(expected int) AssertableInt {
 }
 
 // IsGreaterThanOrEqualTo asserts if the assertable int value is greater than or equal to the expected value
-// It errors the tests if is not greater
+// It errors the tests if is not greater.
 func (a AssertableInt) IsGreaterThanOrEqualTo(expected int) AssertableInt {
 	if !a.actual.IsGreaterOrEqualTo(expected) {
 		a.t.Error(shouldBeGreaterOrEqual(a.actual, expected))
@@ -57,7 +58,7 @@ func (a AssertableInt) IsGreaterThanOrEqualTo(expected int) AssertableInt {
 }
 
 // IsLessThan asserts if the assertable int value is less than the expected value
-// It errors the tests if is not greater
+// It errors the tests if is not greater.
 func (a AssertableInt) IsLessThan(expected int) AssertableInt {
 	if !a.actual.IsLessThan(expected) {
 		a.t.Error(shouldBeLessThan(a.actual, expected))
@@ -66,7 +67,7 @@ func (a AssertableInt) IsLessThan(expected int) AssertableInt {
 }
 
 // IsLessThanOrEqualTo asserts if the assertable int value is less than or equal to the expected value
-// It errors the tests if is not greater
+// It errors the tests if is not greater.
 func (a AssertableInt) IsLessThanOrEqualTo(expected int) AssertableInt {
 	if !a.actual.IsLessOrEqualTo(expected) {
 		a.t.Error(shouldBeLessOrEqual(a.actual, expected))

--- a/assert/map.go
+++ b/assert/map.go
@@ -7,14 +7,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/types"
 )
 
-// AssertableMap is the structure to assert maps
+// AssertableMap is the structure to assert maps.
 type AssertableMap struct {
 	t      *testing.T
 	actual types.Map
 }
 
-// ThatMap returns a proper assertable structure based on the map key type
+// ThatMap returns a proper assertable structure based on the map key type.
 func ThatMap(t *testing.T, actual interface{}) AssertableMap {
+	t.Helper()
 	return AssertableMap{
 		t:      t,
 		actual: values.NewKeyStringMap(actual),
@@ -22,7 +23,7 @@ func ThatMap(t *testing.T, actual interface{}) AssertableMap {
 }
 
 // IsEqualTo asserts if the expected map is equal to the assertable map value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableMap) IsEqualTo(expected interface{}) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -36,7 +37,7 @@ func (a AssertableMap) IsEqualTo(expected interface{}) AssertableMap {
 }
 
 // IsNotEqualTo asserts if the expected map is not equal to the assertable map value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableMap) IsNotEqualTo(expected interface{}) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -49,7 +50,7 @@ func (a AssertableMap) IsNotEqualTo(expected interface{}) AssertableMap {
 }
 
 // HasSize asserts if the assertable string map has the expected length size
-// It errors the test if it doesn't have the expected size
+// It errors the test if it doesn't have the expected size.
 func (a AssertableMap) HasSize(size int) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -61,7 +62,7 @@ func (a AssertableMap) HasSize(size int) AssertableMap {
 	return a
 }
 
-// IsEmpty asserts if the assertable string map is empty or not
+// IsEmpty asserts if the assertable string map is empty or not.
 func (a AssertableMap) IsEmpty() AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -73,7 +74,7 @@ func (a AssertableMap) IsEmpty() AssertableMap {
 	return a
 }
 
-// IsNotEmpty asserts if the assertable string map is not empty
+// IsNotEmpty asserts if the assertable string map is not empty.
 func (a AssertableMap) IsNotEmpty() AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -89,7 +90,7 @@ func (a AssertableMap) IsNotEmpty() AssertableMap {
 // It errors the test if
 // * they key can't be found
 // * the key is not comparable
-// * the asserted type is not a map
+// * the asserted type is not a map.
 func (a AssertableMap) HasKey(elements interface{}) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -105,7 +106,7 @@ func (a AssertableMap) HasKey(elements interface{}) AssertableMap {
 // It errors the test if
 // * they key can't be found
 // * the key is not comparable
-// * the asserted type is not a map
+// * the asserted type is not a map.
 func (a AssertableMap) HasValue(elements interface{}) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -121,7 +122,7 @@ func (a AssertableMap) HasValue(elements interface{}) AssertableMap {
 // It errors the test if
 // * they entry can't be found
 // * the key is not comparable
-// * the asserted type is not a map
+// * the asserted type is not a map.
 func (a AssertableMap) HasEntry(value types.MapEntry) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -137,7 +138,7 @@ func (a AssertableMap) HasEntry(value types.MapEntry) AssertableMap {
 // It errors the test if
 // * they key is found
 // * the key is not comparable
-// * the asserted type is not a map
+// * the asserted type is not a map.
 func (a AssertableMap) HasNotKey(elements interface{}) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -153,7 +154,7 @@ func (a AssertableMap) HasNotKey(elements interface{}) AssertableMap {
 // It errors the test if
 // * they key can be found
 // * the key is not comparable
-// * the asserted type is not a map
+// * the asserted type is not a map.
 func (a AssertableMap) HasNotValue(elements interface{}) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))
@@ -169,7 +170,7 @@ func (a AssertableMap) HasNotValue(elements interface{}) AssertableMap {
 // It errors the test if
 // * they entry can be found
 // * the key is not comparable
-// * the asserted type is not a map
+// * the asserted type is not a map.
 func (a AssertableMap) HasNotEntry(value types.MapEntry) AssertableMap {
 	if !values.IsMap(a.actual.Value()) {
 		a.t.Error(shouldBeMap(a.actual))

--- a/assert/slice.go
+++ b/assert/slice.go
@@ -7,25 +7,26 @@ import (
 	"github.com/ppapapetrou76/go-testing/types"
 )
 
-// SliceOpt is a configuration option to initialize an AssertableAny Slice
+// SliceOpt is a configuration option to initialize an AssertableAny Slice.
 type SliceOpt func(*AssertableSlice)
 
-// AssertableSlice is the implementation of AssertableSlice for string slices
+// AssertableSlice is the implementation of AssertableSlice for string slices.
 type AssertableSlice struct {
 	t             *testing.T
 	actual        types.Containable
 	customMessage string
 }
 
-// WithCustomMessage provides a custom message to be added before the assertion error message
+// WithCustomMessage provides a custom message to be added before the assertion error message.
 func WithCustomMessage(customMessage string) SliceOpt {
 	return func(c *AssertableSlice) {
 		c.customMessage = customMessage
 	}
 }
 
-// ThatSlice returns a proper assertable structure based on the slice type
+// ThatSlice returns a proper assertable structure based on the slice type.
 func ThatSlice(t *testing.T, actual interface{}, opts ...SliceOpt) AssertableSlice {
+	t.Helper()
 	assertable := &AssertableSlice{
 		t:      t,
 		actual: values.NewSliceValue(actual),
@@ -37,7 +38,7 @@ func ThatSlice(t *testing.T, actual interface{}, opts ...SliceOpt) AssertableSli
 }
 
 // IsEqualTo asserts if the expected slice is equal to the assertable slice value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableSlice) IsEqualTo(expected interface{}) AssertableSlice {
 	if !a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -46,7 +47,7 @@ func (a AssertableSlice) IsEqualTo(expected interface{}) AssertableSlice {
 }
 
 // IsNotEqualTo asserts if the expected slice is not equal to the assertable slice value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableSlice) IsNotEqualTo(expected interface{}) AssertableSlice {
 	if a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -55,7 +56,7 @@ func (a AssertableSlice) IsNotEqualTo(expected interface{}) AssertableSlice {
 }
 
 // HasSize asserts if the assertable string slice has the expected length size
-// It errors the test if it doesn't have the expected size
+// It errors the test if it doesn't have the expected size.
 func (a AssertableSlice) HasSize(size int) AssertableSlice {
 	if !a.actual.HasSize(size) {
 		a.t.Error(shouldHaveSize(a.actual, size))
@@ -63,7 +64,7 @@ func (a AssertableSlice) HasSize(size int) AssertableSlice {
 	return a
 }
 
-// IsEmpty asserts if the assertable string slice is empty or not
+// IsEmpty asserts if the assertable string slice is empty or not.
 func (a AssertableSlice) IsEmpty() AssertableSlice {
 	if a.actual.IsNotEmpty() {
 		a.t.Error(shouldBeEmpty(a.actual))
@@ -71,7 +72,7 @@ func (a AssertableSlice) IsEmpty() AssertableSlice {
 	return a
 }
 
-// IsNotEmpty asserts if the assertable string slice is not empty
+// IsNotEmpty asserts if the assertable string slice is not empty.
 func (a AssertableSlice) IsNotEmpty() AssertableSlice {
 	if a.actual.IsEmpty() {
 		a.t.Error(shouldNotBeEmpty(a.actual))
@@ -80,7 +81,7 @@ func (a AssertableSlice) IsNotEmpty() AssertableSlice {
 }
 
 // Contains asserts if the assertable string slice contains the given element(s)
-// It errors the test if it does not contain it/them
+// It errors the test if it does not contain it/them.
 func (a AssertableSlice) Contains(elements interface{}) AssertableSlice {
 	if a.actual.DoesNotContain(elements) {
 		a.t.Error(shouldContain(a.actual, elements))
@@ -89,7 +90,7 @@ func (a AssertableSlice) Contains(elements interface{}) AssertableSlice {
 }
 
 // ContainsOnly asserts if the assertable string slice contains only the given element(s)
-// It errors the test if it does not contain it/them
+// It errors the test if it does not contain it/them.
 func (a AssertableSlice) ContainsOnly(elements interface{}) AssertableSlice {
 	if !a.actual.ContainsOnly(elements) {
 		a.t.Error(shouldContainOnly(a.actual, elements))
@@ -98,7 +99,7 @@ func (a AssertableSlice) ContainsOnly(elements interface{}) AssertableSlice {
 }
 
 // DoesNotContain asserts if the assertable string slice does not contain the given element
-// It errors the test if it contains it/them
+// It errors the test if it contains it/them.
 func (a AssertableSlice) DoesNotContain(elements interface{}) AssertableSlice {
 	if a.actual.Contains(elements) {
 		a.t.Error(shouldNotContain(a.actual, elements))

--- a/assert/slice_test.go
+++ b/assert/slice_test.go
@@ -203,6 +203,11 @@ func TestAssertableSlice_HasSize(t *testing.T) {
 }
 
 func TestAssertableSlice_Contains(t *testing.T) {
+	type testStruct struct {
+		Value1 string
+		Value2 int
+	}
+
 	tests := []struct {
 		name              string
 		actual            interface{}
@@ -232,6 +237,24 @@ func TestAssertableSlice_Contains(t *testing.T) {
 			actual:            2,
 			elementsToContain: []string{"element", "element4"},
 			shouldFail:        true,
+		},
+		{
+			name: "should succeed if contains runs on a single element not wrapped as slice",
+			actual: []testStruct{
+				{
+					Value1: "123",
+					Value2: 123,
+				},
+				{
+					Value1: "133",
+					Value2: 133,
+				},
+			},
+			elementsToContain: testStruct{
+				Value1: "123",
+				Value2: 123,
+			},
+			shouldFail: false,
 		},
 	}
 	for _, tt := range tests {

--- a/assert/string.go
+++ b/assert/string.go
@@ -7,24 +7,25 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/values"
 )
 
-// StringOpt is a configuration option to initialize an AssertableString
+// StringOpt is a configuration option to initialize an AssertableString.
 type StringOpt func(*AssertableString)
 
-// AssertableString is the implementation of CommonAssertable for string types
+// AssertableString is the implementation of CommonAssertable for string types.
 type AssertableString struct {
 	t      *testing.T
 	actual values.StringValue
 }
 
-// IgnoringCase sets underlying value to lower case
+// IgnoringCase sets underlying value to lower case.
 func IgnoringCase() StringOpt {
 	return func(c *AssertableString) {
 		c.actual = c.actual.AddDecorator(strings.ToLower)
 	}
 }
 
-// ThatString returns an AssertableString structure initialized with the test reference and the actual value to assert
+// ThatString returns an AssertableString structure initialized with the test reference and the actual value to assert.
 func ThatString(t *testing.T, actual string, opts ...StringOpt) AssertableString {
+	t.Helper()
 	assertable := &AssertableString{
 		t:      t,
 		actual: values.NewStringValue(actual),
@@ -36,7 +37,7 @@ func ThatString(t *testing.T, actual string, opts ...StringOpt) AssertableString
 }
 
 // IsEqualTo asserts if the expected string is equal to the assertable string value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableString) IsEqualTo(expected interface{}) AssertableString {
 	if !a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -45,7 +46,7 @@ func (a AssertableString) IsEqualTo(expected interface{}) AssertableString {
 }
 
 // IsNotEqualTo asserts if the expected string is not equal to the assertable string value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableString) IsNotEqualTo(expected interface{}) AssertableString {
 	if a.actual.IsEqualTo(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -54,7 +55,7 @@ func (a AssertableString) IsNotEqualTo(expected interface{}) AssertableString {
 }
 
 // IsEmpty asserts if the expected string is empty
-// It errors the tests if the string is not empty
+// It errors the tests if the string is not empty.
 func (a AssertableString) IsEmpty() AssertableString {
 	if a.actual.IsNotEmpty() {
 		a.t.Error(shouldBeEmpty(a.actual))
@@ -63,7 +64,7 @@ func (a AssertableString) IsEmpty() AssertableString {
 }
 
 // IsNotEmpty asserts if the expected string is not empty
-// It errors the tests if the string is empty
+// It errors the tests if the string is empty.
 func (a AssertableString) IsNotEmpty() AssertableString {
 	if a.actual.IsEmpty() {
 		a.t.Error(shouldNotBeEmpty(a.actual))
@@ -72,7 +73,7 @@ func (a AssertableString) IsNotEmpty() AssertableString {
 }
 
 // Contains asserts if the assertable string contains the given element(s)
-// It errors the test if it does not contain it
+// It errors the test if it does not contain it.
 func (a AssertableString) Contains(substring string) AssertableString {
 	if a.actual.DoesNotContain(substring) {
 		a.t.Error(shouldContain(a.actual, substring))
@@ -81,7 +82,7 @@ func (a AssertableString) Contains(substring string) AssertableString {
 }
 
 // ContainsIgnoringCase asserts if the assertable string contains the given element(s) case insensitively
-// It errors the test if it does not contain it
+// It errors the test if it does not contain it.
 func (a AssertableString) ContainsIgnoringCase(substring string) AssertableString {
 	if !a.actual.ContainsIgnoringCase(substring) {
 		a.t.Error(shouldContainIgnoringCase(a.actual, substring))
@@ -90,7 +91,7 @@ func (a AssertableString) ContainsIgnoringCase(substring string) AssertableStrin
 }
 
 // ContainsOnly asserts if the assertable string only contains the given substring
-// It errors the test if it does not contain it
+// It errors the test if it does not contain it.
 func (a AssertableString) ContainsOnly(substring string) AssertableString {
 	if !a.actual.ContainsOnly(substring) {
 		a.t.Error(shouldContainOnly(a.actual, substring))
@@ -99,7 +100,7 @@ func (a AssertableString) ContainsOnly(substring string) AssertableString {
 }
 
 // ContainsOnlyOnce asserts if the assertable string contains the given substring only once
-// It errors the test if it does not contain it or contains more than once
+// It errors the test if it does not contain it or contains more than once.
 func (a AssertableString) ContainsOnlyOnce(substring string) AssertableString {
 	if !a.actual.ContainsOnlyOnce(substring) {
 		a.t.Error(shouldContainOnlyOnce(a.actual, substring))
@@ -108,7 +109,7 @@ func (a AssertableString) ContainsOnlyOnce(substring string) AssertableString {
 }
 
 // DoesNotContain asserts if the assertable string does not contain the given substring
-// It errors the test if it contains it
+// It errors the test if it contains it.
 func (a AssertableString) DoesNotContain(substring string) AssertableString {
 	if a.actual.Contains(substring) {
 		a.t.Error(shouldNotContain(a.actual, substring))
@@ -117,7 +118,7 @@ func (a AssertableString) DoesNotContain(substring string) AssertableString {
 }
 
 // StartsWith asserts if the assertable string starts with the given substring
-// It errors the test if it doesn't start with the given substring
+// It errors the test if it doesn't start with the given substring.
 func (a AssertableString) StartsWith(substring string) AssertableString {
 	if !a.actual.StartsWith(substring) {
 		a.t.Error(shouldStartWith(a.actual, substring))
@@ -126,7 +127,7 @@ func (a AssertableString) StartsWith(substring string) AssertableString {
 }
 
 // EndsWith asserts if the assertable string ends with the given substring
-// It errors the test if it doesn't end with the given substring
+// It errors the test if it doesn't end with the given substring.
 func (a AssertableString) EndsWith(substring string) AssertableString {
 	if !a.actual.EndsWith(substring) {
 		a.t.Error(shouldEndWith(a.actual, substring))
@@ -135,7 +136,7 @@ func (a AssertableString) EndsWith(substring string) AssertableString {
 }
 
 // HasSameSizeAs asserts if the assertable string has the same size with the given string
-// It errors the test if they don't have the same size
+// It errors the test if they don't have the same size.
 func (a AssertableString) HasSameSizeAs(substring string) AssertableString {
 	if !(a.actual.Size() == len(substring)) {
 		a.t.Error(shouldHaveSameSizeAs(a.actual, substring))
@@ -144,7 +145,7 @@ func (a AssertableString) HasSameSizeAs(substring string) AssertableString {
 }
 
 // ContainsOnlyDigits asserts if the expected string contains only digits
-// It errors the tests if the string has other characters than digits
+// It errors the tests if the string has other characters than digits.
 func (a AssertableString) ContainsOnlyDigits() AssertableString {
 	if !(a.actual.HasDigitsOnly()) {
 		a.t.Error(shouldContainOnlyDigits(a.actual))

--- a/assert/structs.go
+++ b/assert/structs.go
@@ -6,14 +6,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/values"
 )
 
-// AssertableStruct is the implementation of AssertableAny for structs
+// AssertableStruct is the implementation of AssertableAny for structs.
 type AssertableStruct struct {
 	actual values.StructValue
 	t      *testing.T
 }
 
-// ThatStruct returns a proper assertable structure based on the slice type
+// ThatStruct returns a proper assertable structure based on the slice type.
 func ThatStruct(t *testing.T, actual interface{}) AssertableStruct {
+	t.Helper()
 	return AssertableStruct{
 		actual: values.NewStructValue(actual),
 		t:      t,
@@ -21,7 +22,7 @@ func ThatStruct(t *testing.T, actual interface{}) AssertableStruct {
 }
 
 // IsEqualTo asserts if the expected structure is equal to the assertable structure value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (s AssertableStruct) IsEqualTo(expected interface{}) AssertableStruct {
 	if !s.actual.IsEqualTo(expected) {
 		s.t.Error(shouldBeEqual(s.actual, expected))
@@ -30,7 +31,7 @@ func (s AssertableStruct) IsEqualTo(expected interface{}) AssertableStruct {
 }
 
 // IsNotEqualTo asserts if the expected structure is not equal to the assertable structure value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (s AssertableStruct) IsNotEqualTo(expected int) AssertableStruct {
 	if s.actual.IsEqualTo(expected) {
 		s.t.Error(shouldNotBeEqual(s.actual, expected))
@@ -38,7 +39,7 @@ func (s AssertableStruct) IsNotEqualTo(expected int) AssertableStruct {
 	return s
 }
 
-// ExcludingFields excludes the given fields from struct comparisons
+// ExcludingFields excludes the given fields from struct comparisons.
 func (s AssertableStruct) ExcludingFields(fields ...string) AssertableStruct {
 	s.actual.ExcludedFields = fields
 	return s

--- a/assert/testing.go
+++ b/assert/testing.go
@@ -5,55 +5,55 @@ import (
 	"time"
 )
 
-// FluentT wraps the testing.T pointer to provide a better experience to the library users
+// FluentT wraps the testing.T pointer to provide a better experience to the library users.
 type FluentT struct {
 	t *testing.T
 }
 
-// NewFluentT creates a new Fluent testing
+// NewFluentT creates a new Fluent testing.
 func NewFluentT(t *testing.T) *FluentT { // nolint
 	return &FluentT{
 		t: t,
 	}
 }
 
-// AssertThatString initializes an assertable string to be used for asserting string properties
+// AssertThatString initializes an assertable string to be used for asserting string properties.
 func (t FluentT) AssertThatString(actual string, opts ...StringOpt) AssertableString {
 	return ThatString(t.t, actual, opts...)
 }
 
-// AssertThatBool initializes an assertable bool to be used for asserting bool properties
+// AssertThatBool initializes an assertable bool to be used for asserting bool properties.
 func (t FluentT) AssertThatBool(actual bool) AssertableBool {
 	return ThatBool(t.t, actual)
 }
 
-// AssertThatInt initializes an assertable int to be used for asserting int properties
+// AssertThatInt initializes an assertable int to be used for asserting int properties.
 func (t FluentT) AssertThatInt(actual int) AssertableInt {
 	return ThatInt(t.t, actual)
 }
 
-// AssertThatSlice initializes an assertable slice to be used for asserting slice properties
+// AssertThatSlice initializes an assertable slice to be used for asserting slice properties.
 func (t FluentT) AssertThatSlice(actual interface{}, opts ...SliceOpt) AssertableSlice {
 	return ThatSlice(t.t, actual, opts...)
 }
 
-// AssertThatStruct initializes an assertable struct to be used for asserting struct properties
+// AssertThatStruct initializes an assertable struct to be used for asserting struct properties.
 func (t FluentT) AssertThatStruct(actual interface{}) AssertableStruct {
 	return ThatStruct(t.t, actual)
 }
 
-// AssertThatTime initializes an assertable time.Time to be used for asserting time.Time properties
+// AssertThatTime initializes an assertable time.Time to be used for asserting time.Time properties.
 func (t FluentT) AssertThatTime(actual time.Time) AssertableTime {
 	return ThatTime(t.t, actual)
 }
 
-// AssertThatDuration initializes an assertable time.Duration to be used for asserting time.Duration properties
+// AssertThatDuration initializes an assertable time.Duration to be used for asserting time.Duration properties.
 func (t FluentT) AssertThatDuration(actual time.Duration) AssertableDuration {
 	return ThatDuration(t.t, actual)
 }
 
 // AssertThat initializes an assertable object to be used for asserting properties of any type
-// The things we can assert using this type are limited
+// The things we can assert using this type are limited.
 func (t FluentT) AssertThat(actual interface{}) AssertableAny {
 	return That(t.t, actual)
 }

--- a/assert/time.go
+++ b/assert/time.go
@@ -7,14 +7,15 @@ import (
 	"github.com/ppapapetrou76/go-testing/internal/pkg/types"
 )
 
-// AssertableTime is the assertable structure for time.Time values
+// AssertableTime is the assertable structure for time.Time values.
 type AssertableTime struct {
 	t      *testing.T
 	actual types.TimeValue
 }
 
-// ThatTime returns an AssertableTime structure initialized with the test reference and the actual value to assert
+// ThatTime returns an AssertableTime structure initialized with the test reference and the actual value to assert.
 func ThatTime(t *testing.T, actual time.Time) AssertableTime {
+	t.Helper()
 	return AssertableTime{
 		t:      t,
 		actual: types.NewTimeValue(actual),
@@ -22,7 +23,7 @@ func ThatTime(t *testing.T, actual time.Time) AssertableTime {
 }
 
 // IsSameAs asserts if the expected time.Time is equal to the assertable time.Time value
-// It errors the tests if the compared values (actual VS expected) are not equal
+// It errors the tests if the compared values (actual VS expected) are not equal.
 func (a AssertableTime) IsSameAs(expected time.Time) AssertableTime {
 	if a.actual.IsNotSameAs(expected) {
 		a.t.Error(shouldBeEqual(a.actual, expected))
@@ -31,7 +32,7 @@ func (a AssertableTime) IsSameAs(expected time.Time) AssertableTime {
 }
 
 // IsNotTheSameAs asserts if the expected time.Time is not equal to the assertable time.Time value
-// It errors the tests if the compared values (actual VS expected) are equal
+// It errors the tests if the compared values (actual VS expected) are equal.
 func (a AssertableTime) IsNotTheSameAs(expected time.Time) AssertableTime {
 	if a.actual.IsSameAs(expected) {
 		a.t.Error(shouldNotBeEqual(a.actual, expected))
@@ -40,7 +41,7 @@ func (a AssertableTime) IsNotTheSameAs(expected time.Time) AssertableTime {
 }
 
 // IsBefore asserts if the assertable time.Time value is before the expected value
-// It errors the tests if is not greater
+// It errors the tests if is not greater.
 func (a AssertableTime) IsBefore(expected time.Time) AssertableTime {
 	if !a.actual.IsBefore(expected) {
 		a.t.Error(shouldBeGreater(a.actual, expected))
@@ -49,7 +50,7 @@ func (a AssertableTime) IsBefore(expected time.Time) AssertableTime {
 }
 
 // IsAfter asserts if the assertable time.Time value is after the expected value
-// It errors the tests if is not later
+// It errors the tests if is not later.
 func (a AssertableTime) IsAfter(expected time.Time) AssertableTime {
 	if !a.actual.IsAfter(expected) {
 		a.t.Error(shouldBeGreaterOrEqual(a.actual, expected))

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ppapapetrou76/go-testing
 
-go 1.12
+go 1.15
 
 require github.com/mbndr/figlet4go v0.0.0-20190224160619-d6cef5b186ea // indirect

--- a/internal/pkg/types/time_value.go
+++ b/internal/pkg/types/time_value.go
@@ -5,32 +5,32 @@ import (
 	"time"
 )
 
-// TimeValue is a struct that holds a time value
+// TimeValue is a struct that holds a time value.
 type TimeValue struct {
 	value time.Time
 }
 
-// IsSameAs returns true if the value is the same as the expected value, else false
+// IsSameAs returns true if the value is the same as the expected value, else false.
 func (t TimeValue) IsSameAs(expected interface{}) bool {
 	return t.value == expected
 }
 
-// IsNotSameAs returns true if the value is not the same as the expected value, else false
+// IsNotSameAs returns true if the value is not the same as the expected value, else false.
 func (t TimeValue) IsNotSameAs(expected interface{}) bool {
 	return t.value != expected
 }
 
-// IsAfter returns true if the value is after than the expected value, else false
+// IsAfter returns true if the value is after than the expected value, else false.
 func (t TimeValue) IsAfter(expected interface{}) bool {
 	return t.isAfter(NewTimeValue(expected))
 }
 
-// IsBefore returns true if the value is before the expected value, else false
+// IsBefore returns true if the value is before the expected value, else false.
 func (t TimeValue) IsBefore(expected interface{}) bool {
 	return t.isBefore(NewTimeValue(expected))
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (t TimeValue) Value() interface{} {
 	return t.value
 }
@@ -43,7 +43,7 @@ func (t TimeValue) isBefore(expected TimeValue) bool {
 	return t.value.Before(expected.value)
 }
 
-// NewTimeValue creates and returns an TimeValue struct initialed with the given value
+// NewTimeValue creates and returns an TimeValue struct initialed with the given value.
 func NewTimeValue(value interface{}) TimeValue {
 	switch v := value.(type) {
 	case time.Time:

--- a/internal/pkg/values/any_value.go
+++ b/internal/pkg/values/any_value.go
@@ -7,14 +7,18 @@ import (
 	"github.com/ppapapetrou76/go-testing/types"
 )
 
-// AnyValue is a struct that holds any type of value
+// AnyValue is a struct that holds any type of value.
 type AnyValue struct {
 	value interface{}
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (s AnyValue) IsEqualTo(expected interface{}) bool {
 	var comparable types.Comparable
+
+	if reflect.ValueOf(s.Value()).Kind() != reflect.ValueOf(expected).Kind() {
+		return false
+	}
 
 	switch expected.(type) {
 	case string:
@@ -36,47 +40,47 @@ func (s AnyValue) IsEqualTo(expected interface{}) bool {
 	return comparable.IsEqualTo(expected)
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (s AnyValue) Value() interface{} {
 	return s.value
 }
 
-// IsGreaterThan returns true if the value is greater than the expected value, else false
+// IsGreaterThan returns true if the value is greater than the expected value, else false.
 func (s AnyValue) IsGreaterThan(expected interface{}) bool {
 	return s.value != expected
 }
 
-// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false
+// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false.
 func (s AnyValue) IsGreaterOrEqualTo(expected interface{}) bool {
 	return s.value != expected
 }
 
-// IsLessThan returns true if the value is less than the expected value, else false
+// IsLessThan returns true if the value is less than the expected value, else false.
 func (s AnyValue) IsLessThan(expected interface{}) bool {
 	return s.value != expected
 }
 
-// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false
+// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false.
 func (s AnyValue) IsLessOrEqualTo(expected interface{}) bool {
 	return s.value != expected
 }
 
-// IsNil returns true if the value is nil, else false
+// IsNil returns true if the value is nil, else false.
 func (s AnyValue) IsNil() bool {
 	return s.value == nil
 }
 
-// IsNotNil returns true if the value is not nil, else false
+// IsNotNil returns true if the value is not nil, else false.
 func (s AnyValue) IsNotNil() bool {
 	return !s.IsNil()
 }
 
-// HasTypeOf returns true if the value is of the given type else false
+// HasTypeOf returns true if the value is of the given type else false.
 func (s AnyValue) HasTypeOf(t reflect.Type) bool {
 	return reflect.TypeOf(s.value) == t
 }
 
-// NewAnyValue creates and returns an AnyValue struct initialed with the given value
+// NewAnyValue creates and returns an AnyValue struct initialed with the given value.
 func NewAnyValue(value interface{}) AnyValue {
 	switch v := value.(type) {
 	case nil:

--- a/internal/pkg/values/bool_value.go
+++ b/internal/pkg/values/bool_value.go
@@ -5,22 +5,22 @@ import (
 	"strconv"
 )
 
-// BoolValue is a struct that holds a bool value
+// BoolValue is a struct that holds a bool value.
 type BoolValue struct {
 	value bool
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (s BoolValue) IsEqualTo(expected interface{}) bool {
 	return s.value == expected
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (s BoolValue) Value() interface{} {
 	return s.value
 }
 
-// NewBoolValue creates and returns an BoolValue struct initialed with the given value
+// NewBoolValue creates and returns an BoolValue struct initialed with the given value.
 func NewBoolValue(value interface{}) BoolValue {
 	switch v := value.(type) {
 	case bool:

--- a/internal/pkg/values/duration_value.go
+++ b/internal/pkg/values/duration_value.go
@@ -5,32 +5,32 @@ import (
 	"time"
 )
 
-// DurationValue is a struct that holds a duration value
+// DurationValue is a struct that holds a duration value.
 type DurationValue struct {
 	value time.Duration
 }
 
-// IsEqualTo returns true if the value is the same as the expected value, else false
+// IsEqualTo returns true if the value is the same as the expected value, else false.
 func (d DurationValue) IsEqualTo(expected interface{}) bool {
 	return d.value == expected
 }
 
-// IsNotEqualTo returns true if the value is not the same as the expected value, else false
+// IsNotEqualTo returns true if the value is not the same as the expected value, else false.
 func (d DurationValue) IsNotEqualTo(expected interface{}) bool {
 	return d.value != expected
 }
 
-// IsLongerThan returns true if the value is longer than the expected value, else false
+// IsLongerThan returns true if the value is longer than the expected value, else false.
 func (d DurationValue) IsLongerThan(expected interface{}) bool {
 	return d.isLonger(NewDurationValue(expected))
 }
 
-// IsShorterThan returns true if the value is shorter than the expected value, else false
+// IsShorterThan returns true if the value is shorter than the expected value, else false.
 func (d DurationValue) IsShorterThan(expected interface{}) bool {
 	return d.isShorter(NewDurationValue(expected))
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (d DurationValue) Value() interface{} {
 	return d.value
 }
@@ -43,7 +43,7 @@ func (d DurationValue) isShorter(expected DurationValue) bool {
 	return d.value < expected.value
 }
 
-// NewDurationValue creates and returns an DurationValue struct initialed with the given value
+// NewDurationValue creates and returns an DurationValue struct initialed with the given value.
 func NewDurationValue(value interface{}) DurationValue {
 	switch v := value.(type) {
 	case time.Duration:

--- a/internal/pkg/values/equal.go
+++ b/internal/pkg/values/equal.go
@@ -26,6 +26,9 @@ func areEqualValues(actualValue, expectedValue reflect.Value) bool {
 		return NewStructValue(actualValue).IsEqualTo(expectedValue)
 	case reflect.Interface:
 		return NewAnyValue(actualValue.Interface()).IsEqualTo(expectedValue.Interface())
+	case reflect.Chan, reflect.Complex64, reflect.Complex128, reflect.Func, reflect.Invalid, reflect.Ptr, reflect.Uintptr, reflect.UnsafePointer:
+		// not supported yet
+		return true
 	default:
 		return true
 	}

--- a/internal/pkg/values/int_value.go
+++ b/internal/pkg/values/int_value.go
@@ -4,37 +4,37 @@ import (
 	"fmt"
 )
 
-// IntValue is a struct that holds an int value
+// IntValue is a struct that holds an int value.
 type IntValue struct {
 	value int
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (i IntValue) IsEqualTo(expected interface{}) bool {
 	return i.equals(NewIntValue(expected))
 }
 
-// IsGreaterThan returns true if the value is greater than the expected value, else false
+// IsGreaterThan returns true if the value is greater than the expected value, else false.
 func (i IntValue) IsGreaterThan(expected interface{}) bool {
 	return i.greaterThan(NewIntValue(expected))
 }
 
-// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false
+// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false.
 func (i IntValue) IsGreaterOrEqualTo(expected interface{}) bool {
 	return i.greaterOrEqual(NewIntValue(expected))
 }
 
-// IsLessThan returns true if the value is less than the expected value, else false
+// IsLessThan returns true if the value is less than the expected value, else false.
 func (i IntValue) IsLessThan(expected interface{}) bool {
 	return !i.IsGreaterOrEqualTo(expected)
 }
 
-// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false
+// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false.
 func (i IntValue) IsLessOrEqualTo(expected interface{}) bool {
 	return !i.IsGreaterThan(expected)
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (i IntValue) Value() interface{} {
 	return i.value
 }
@@ -51,7 +51,7 @@ func (i IntValue) equals(expected IntValue) bool {
 	return i.value == expected.value
 }
 
-// NewIntValue creates and returns an IntValue struct initialed with the given value
+// NewIntValue creates and returns an IntValue struct initialed with the given value.
 func NewIntValue(value interface{}) IntValue {
 	switch v := value.(type) {
 	case int:

--- a/internal/pkg/values/map_value.go
+++ b/internal/pkg/values/map_value.go
@@ -6,17 +6,17 @@ import (
 	"github.com/ppapapetrou76/go-testing/types"
 )
 
-// MapValue is a struct that holds a string map value
+// MapValue is a struct that holds a string map value.
 type MapValue struct {
 	value interface{}
 }
 
-// Value returns the actual value of the map
+// Value returns the actual value of the map.
 func (s MapValue) Value() interface{} {
 	return s.value
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (s MapValue) IsEqualTo(expected interface{}) bool {
 	if !IsMap(expected) {
 		return false
@@ -31,22 +31,22 @@ func (s MapValue) IsEqualTo(expected interface{}) bool {
 	return areMapsEqual(actualValue, expectedValue)
 }
 
-// IsEmpty returns true if the map is empty else false
+// IsEmpty returns true if the map is empty else false.
 func (s MapValue) IsEmpty() bool {
 	return s.HasSize(0)
 }
 
-// IsNotEmpty returns true if the map is not empty else false
+// IsNotEmpty returns true if the map is not empty else false.
 func (s MapValue) IsNotEmpty() bool {
 	return !s.IsEmpty()
 }
 
-// HasSize returns true if the map has the expected size else false
+// HasSize returns true if the map has the expected size else false.
 func (s MapValue) HasSize(length int) bool {
 	return s.Size() == length
 }
 
-// Size returns the map size
+// Size returns the map size.
 func (s MapValue) Size() int {
 	if !IsMap(s.Value()) {
 		return 0
@@ -61,12 +61,12 @@ func (s MapValue) hasKeyValue(key, value interface{}) bool {
 	return areEqualValues(keyValue, reflect.ValueOf(value))
 }
 
-// HasEntry returns true if the map has the given key,value pair (map entry)
+// HasEntry returns true if the map has the given key,value pair (map entry).
 func (s MapValue) HasEntry(entry types.MapEntry) bool {
 	return s.HasKey(entry.Key()) && s.hasKeyValue(entry.Key(), entry.Value())
 }
 
-// HasKey returns true if the map has the given key
+// HasKey returns true if the map has the given key.
 func (s MapValue) HasKey(key interface{}) bool {
 	if !reflect.TypeOf(key).Comparable() {
 		return false
@@ -76,7 +76,7 @@ func (s MapValue) HasKey(key interface{}) bool {
 	return actualValue.MapIndex(reflect.ValueOf(key)).IsValid()
 }
 
-// HasValue returns true if the map has the given value
+// HasValue returns true if the map has the given value.
 func (s MapValue) HasValue(value interface{}) bool {
 	actualValue := reflect.ValueOf(s.Value())
 	keys := reflect.ValueOf(s.Value()).MapKeys()
@@ -88,12 +88,12 @@ func (s MapValue) HasValue(value interface{}) bool {
 	return false
 }
 
-// NewKeyStringMap creates and returns a MapValue struct initialed with the given value
+// NewKeyStringMap creates and returns a MapValue struct initialed with the given value.
 func NewKeyStringMap(value interface{}) MapValue {
 	return MapValue{value: value}
 }
 
-// IsMap returns true if the given value is a map, else false
+// IsMap returns true if the given value is a map, else false.
 func IsMap(value interface{}) bool {
 	return reflect.ValueOf(value).Kind() == reflect.Map
 }

--- a/internal/pkg/values/slice_value.go
+++ b/internal/pkg/values/slice_value.go
@@ -4,12 +4,12 @@ import (
 	"reflect"
 )
 
-// SliceValue is a struct that holds a string slice value
+// SliceValue is a struct that holds a string slice value.
 type SliceValue struct {
 	value interface{}
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (s SliceValue) IsEqualTo(expected interface{}) bool {
 	if !IsSlice(expected) || !IsSlice(s.Value()) {
 		return false
@@ -20,22 +20,22 @@ func (s SliceValue) IsEqualTo(expected interface{}) bool {
 	return areSlicesEqual(actualValue, expectedValue)
 }
 
-// IsEmpty returns true if the slice is empty else false
+// IsEmpty returns true if the slice is empty else false.
 func (s SliceValue) IsEmpty() bool {
 	return s.HasSize(0)
 }
 
-// IsNotEmpty returns true if the slice is not empty else false
+// IsNotEmpty returns true if the slice is not empty else false.
 func (s SliceValue) IsNotEmpty() bool {
 	return !s.IsEmpty()
 }
 
-// HasSize returns true if the slice has the expected size else false
+// HasSize returns true if the slice has the expected size else false.
 func (s SliceValue) HasSize(length int) bool {
 	return s.Size() == length
 }
 
-// Size returns the slice size
+// Size returns the slice size.
 func (s SliceValue) Size() int {
 	if !IsSlice(s.Value()) {
 		return 0
@@ -54,7 +54,7 @@ func (s SliceValue) contains(element reflect.Value) bool {
 	return false
 }
 
-// Contains returns true if the slice contains the expected element(s) else false
+// Contains returns true if the slice contains the expected element(s) else false.
 func (s SliceValue) Contains(elements interface{}) bool {
 	if !IsSlice(s.Value()) {
 		return false
@@ -65,7 +65,7 @@ func (s SliceValue) Contains(elements interface{}) bool {
 	}
 
 	expectedValue := reflect.ValueOf(elements)
-	var all = true
+	all := true
 
 	for i := 0; i < expectedValue.Len(); i++ {
 		all = all && s.contains(expectedValue.Index(i))
@@ -73,27 +73,27 @@ func (s SliceValue) Contains(elements interface{}) bool {
 	return all
 }
 
-// DoesNotContain returns true if the slice does not contain the expected element(s) else false
+// DoesNotContain returns true if the slice does not contain the expected element(s) else false.
 func (s SliceValue) DoesNotContain(elements interface{}) bool {
 	return !s.Contains(elements)
 }
 
-// ContainsOnly returns true if the slice contains only the expected element(s) else false
+// ContainsOnly returns true if the slice contains only the expected element(s) else false.
 func (s SliceValue) ContainsOnly(elements interface{}) bool {
 	return s.Contains(elements) && s.HasSize(reflect.ValueOf(elements).Len())
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (s SliceValue) Value() interface{} {
 	return s.value
 }
 
-// NewSliceValue creates and returns a SliceValue struct initialed with the given value
+// NewSliceValue creates and returns a SliceValue struct initialed with the given value.
 func NewSliceValue(value interface{}) SliceValue {
 	return SliceValue{value: value}
 }
 
-// IsSlice returns true if the given value is a slice, else false
+// IsSlice returns true if the given value is a slice, else false.
 func IsSlice(value interface{}) bool {
 	return reflect.ValueOf(value).Kind() == reflect.Slice || reflect.ValueOf(value).Kind() == reflect.Array
 }

--- a/internal/pkg/values/string_value.go
+++ b/internal/pkg/values/string_value.go
@@ -6,97 +6,97 @@ import (
 	"unicode"
 )
 
-// StringValue value represents a string value
+// StringValue value represents a string value.
 type StringValue struct {
 	value      string
 	decorators []StringDecorator
 }
 
-// StringDecorator is a function type to decorate a string
+// StringDecorator is a function type to decorate a string.
 type StringDecorator func(value string) string
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (s StringValue) IsEqualTo(expected interface{}) bool {
 	return s.DecoratedValue() == s.decoratedValue(expected)
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (s StringValue) Value() interface{} {
 	return s.value
 }
 
-// IsGreaterThan returns true if the value is greater than the expected value, else false
+// IsGreaterThan returns true if the value is greater than the expected value, else false.
 func (s StringValue) IsGreaterThan(expected interface{}) bool {
 	return s.greaterThan(NewStringValue(s.decoratedValue(expected)))
 }
 
-// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false
+// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false.
 func (s StringValue) IsGreaterOrEqualTo(expected interface{}) bool {
 	return s.greaterOrEqual(NewStringValue(s.decoratedValue(expected)))
 }
 
-// IsLessThan returns true if the value is less than the expected value, else false
+// IsLessThan returns true if the value is less than the expected value, else false.
 func (s StringValue) IsLessThan(expected interface{}) bool {
 	return !s.IsGreaterOrEqualTo(s.decoratedValue(expected))
 }
 
-// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false
+// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false.
 func (s StringValue) IsLessOrEqualTo(expected interface{}) bool {
 	return !s.IsGreaterThan(s.decoratedValue(expected))
 }
 
-// IsEmpty returns true if the string is empty else false
+// IsEmpty returns true if the string is empty else false.
 func (s StringValue) IsEmpty() bool {
 	return s.DecoratedValue() == ""
 }
 
-// IsNotEmpty returns true if the string is not empty else false
+// IsNotEmpty returns true if the string is not empty else false.
 func (s StringValue) IsNotEmpty() bool {
 	return !s.IsEmpty()
 }
 
-// Contains returns true if the string contains the given sub-string
+// Contains returns true if the string contains the given sub-string.
 func (s StringValue) Contains(expected interface{}) bool {
 	return strings.Contains(s.DecoratedValue(), NewStringValue(s.decoratedValue(expected)).value)
 }
 
-// ContainsIgnoringCase returns true if the string contains the given sub-string case insensitively
+// ContainsIgnoringCase returns true if the string contains the given sub-string case insensitively.
 func (s StringValue) ContainsIgnoringCase(expected interface{}) bool {
 	return strings.Contains(strings.ToLower(s.DecoratedValue()), NewStringValue(strings.ToLower(s.decoratedValue(expected))).value)
 }
 
-// DoesNotContain returns true if the string does not contain the given sub-string
+// DoesNotContain returns true if the string does not contain the given sub-string.
 func (s StringValue) DoesNotContain(expected interface{}) bool {
 	return !s.Contains(s.decoratedValue(expected))
 }
 
-// HasSize returns true if the string has the expected size else false
+// HasSize returns true if the string has the expected size else false.
 func (s StringValue) HasSize(length int) bool {
 	return s.Size() == length
 }
 
-// Size returns the string size
+// Size returns the string size.
 func (s StringValue) Size() int {
 	return len(s.value)
 }
 
-// StartsWith returns true if the asserted value starts with the given string, else false
+// StartsWith returns true if the asserted value starts with the given string, else false.
 func (s StringValue) StartsWith(substr string) bool {
 	return strings.HasPrefix(s.DecoratedValue(), s.decoratedValue(substr))
 }
 
-// EndsWith returns true if the asserted value ends with the given string, else false
+// EndsWith returns true if the asserted value ends with the given string, else false.
 func (s StringValue) EndsWith(substr string) bool {
 	return strings.HasSuffix(s.DecoratedValue(), s.decoratedValue(substr))
 }
 
 // ContainsOnly returns true if the string contains only the given sub-string
-// In other words if performs an equal operation
+// In other words if performs an equal operation.
 func (s StringValue) ContainsOnly(expected interface{}) bool {
 	return s.IsEqualTo(s.decoratedValue(expected))
 }
 
-// ContainsOnlyOnce returns true if the string contains the given sub-string only once
+// ContainsOnlyOnce returns true if the string contains the given sub-string only once.
 func (s StringValue) ContainsOnlyOnce(substr string) bool {
 	return strings.Count(s.DecoratedValue(), s.decoratedValue(substr)) == 1
 }
@@ -109,7 +109,7 @@ func (s StringValue) greaterOrEqual(expected StringValue) bool {
 	return s.DecoratedValue() >= expected.value
 }
 
-// HasDigitsOnly returns true if the string has only digits else false
+// HasDigitsOnly returns true if the string has only digits else false.
 func (s StringValue) HasDigitsOnly() bool {
 	for _, c := range s.DecoratedValue() {
 		if !unicode.IsDigit(c) {
@@ -119,7 +119,7 @@ func (s StringValue) HasDigitsOnly() bool {
 	return true
 }
 
-// NewStringValue creates and returns a StringValue struct initialed with the given value
+// NewStringValue creates and returns a StringValue struct initialed with the given value.
 func NewStringValue(value interface{}) StringValue {
 	switch v := value.(type) {
 	case string:
@@ -129,7 +129,7 @@ func NewStringValue(value interface{}) StringValue {
 	}
 }
 
-// AddDecorator adds a new string decorator to the assertable string value
+// AddDecorator adds a new string decorator to the assertable string value.
 func (s StringValue) AddDecorator(decorator StringDecorator) StringValue {
 	s.decorators = append(s.decorators, decorator)
 	return s
@@ -143,7 +143,7 @@ func (s StringValue) decoratedValue(value interface{}) string {
 	return decoratedValue
 }
 
-// DecoratedValue returns the asserted string value after applying all the defined decorators
+// DecoratedValue returns the asserted string value after applying all the defined decorators.
 func (s StringValue) DecoratedValue() string {
 	return s.decoratedValue(s.value)
 }

--- a/internal/pkg/values/struct_value.go
+++ b/internal/pkg/values/struct_value.go
@@ -2,13 +2,13 @@ package values
 
 import "reflect"
 
-// StructValue is a struct that holds a struct value
+// StructValue is a struct that holds a struct value.
 type StructValue struct {
 	value          interface{}
 	ExcludedFields []string
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (s StructValue) IsEqualTo(expected interface{}) bool {
 	if s.value == nil && expected == nil {
 		return true
@@ -46,12 +46,12 @@ func (s StructValue) IsEqualTo(expected interface{}) bool {
 	return true
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (s StructValue) Value() interface{} {
 	return s.value
 }
 
-// NewStructValue creates and returns a StructValue struct initialed with the given value
+// NewStructValue creates and returns a StructValue struct initialed with the given value.
 func NewStructValue(value interface{}) StructValue {
 	return StructValue{value: value}
 }

--- a/internal/pkg/values/uint_value.go
+++ b/internal/pkg/values/uint_value.go
@@ -4,37 +4,37 @@ import (
 	"fmt"
 )
 
-// UIntValue is a struct that holds a uint value
+// UIntValue is a struct that holds a uint value.
 type UIntValue struct {
 	value uint
 }
 
-// IsEqualTo returns true if the value is equal to the expected value, else false
+// IsEqualTo returns true if the value is equal to the expected value, else false.
 func (i UIntValue) IsEqualTo(expected interface{}) bool {
 	return i.equals(NewUIntValue(expected))
 }
 
-// IsGreaterThan returns true if the value is greater than the expected value, else false
+// IsGreaterThan returns true if the value is greater than the expected value, else false.
 func (i UIntValue) IsGreaterThan(expected interface{}) bool {
 	return i.greaterThan(NewUIntValue(expected))
 }
 
-// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false
+// IsGreaterOrEqualTo returns true if the value is greater than or equal to the expected value, else false.
 func (i UIntValue) IsGreaterOrEqualTo(expected interface{}) bool {
 	return i.greaterOrEqual(NewUIntValue(expected))
 }
 
-// IsLessThan returns true if the value is less than the expected value, else false
+// IsLessThan returns true if the value is less than the expected value, else false.
 func (i UIntValue) IsLessThan(expected interface{}) bool {
 	return !i.IsGreaterOrEqualTo(expected)
 }
 
-// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false
+// IsLessOrEqualTo returns true if the value is less than or equal to the expected value, else false.
 func (i UIntValue) IsLessOrEqualTo(expected interface{}) bool {
 	return !i.IsGreaterThan(expected)
 }
 
-// Value returns the actual value of the structure
+// Value returns the actual value of the structure.
 func (i UIntValue) Value() interface{} {
 	return i.value
 }
@@ -51,7 +51,7 @@ func (i UIntValue) equals(expected UIntValue) bool {
 	return i.value == expected.value
 }
 
-// NewUIntValue creates and returns a UIntValue struct initialed with the given value
+// NewUIntValue creates and returns a UIntValue struct initialed with the given value.
 func NewUIntValue(value interface{}) UIntValue {
 	switch v := value.(type) {
 	case uint:

--- a/types/types.go
+++ b/types/types.go
@@ -1,17 +1,17 @@
 package types
 
-// Assertable is the basic interface for all assertable values
+// Assertable is the basic interface for all assertable values.
 type Assertable interface {
 	Value() interface{}
 }
 
-// Comparable is the interface for basic comparable operations
+// Comparable is the interface for basic comparable operations.
 type Comparable interface {
 	IsEqualTo(expected interface{}) bool
 	Assertable
 }
 
-// ExtendedComparable is the interface for advanced comparable operations
+// ExtendedComparable is the interface for advanced comparable operations.
 type ExtendedComparable interface {
 	IsGreaterOrEqualTo(expected interface{}) bool
 	IsGreaterThan(expected interface{}) bool
@@ -20,7 +20,7 @@ type ExtendedComparable interface {
 	Comparable
 }
 
-// Sizeable is the interface for operations related to sizeable values
+// Sizeable is the interface for operations related to sizeable values.
 type Sizeable interface {
 	IsEmpty() bool
 	IsNotEmpty() bool
@@ -29,7 +29,7 @@ type Sizeable interface {
 	Comparable
 }
 
-// Containable is the interface for operations related to containable values such as string or slice
+// Containable is the interface for operations related to containable values such as string or slice.
 type Containable interface {
 	Contains(elements interface{}) bool
 	ContainsOnly(elements interface{}) bool
@@ -37,14 +37,14 @@ type Containable interface {
 	Sizeable
 }
 
-// Nullable is the interface for operations related to nullable values such as pointers or slices
+// Nullable is the interface for operations related to nullable values such as pointers or slices.
 type Nullable interface {
 	IsNil() bool
 	IsNotNil() bool
 	Assertable
 }
 
-// Map is the interface for operations related to map values
+// Map is the interface for operations related to map values.
 type Map interface {
 	HasKey(key interface{}) bool
 	HasValue(value interface{}) bool
@@ -52,22 +52,22 @@ type Map interface {
 	Sizeable
 }
 
-// MapEntry is the struct to represent a key-value pair used in maps
+// MapEntry is the struct to represent a key-value pair used in maps.
 type MapEntry struct {
 	key, value interface{}
 }
 
-// Key returns the key of the map entry
+// Key returns the key of the map entry.
 func (entry MapEntry) Key() interface{} {
 	return entry.key
 }
 
-// Value returns the value of the map entry
+// Value returns the value of the map entry.
 func (entry MapEntry) Value() interface{} {
 	return entry.value
 }
 
-// NewMapEntry creates and returns a new map entry with the given values of key and value fields
+// NewMapEntry creates and returns a new map entry with the given values of key and value fields.
 func NewMapEntry(key, value interface{}) MapEntry {
 	return MapEntry{
 		key:   key,


### PR DESCRIPTION
 Bumps golangci linter to 1.37.1
Excludes new-linters that don't make sense
Addresses newborn issues
